### PR TITLE
Harden ProGuard rules for vbpd-reflection

### DIFF
--- a/vbpd-reflection/proguard-rules.pro
+++ b/vbpd-reflection/proguard-rules.pro
@@ -1,4 +1,5 @@
 -keep,allowoptimization class * implements androidx.viewbinding.ViewBinding {
     public static *** bind(android.view.View);
-    public static *** inflate(...);
+    public static *** inflate(android.view.LayoutInflater);
+    public static *** inflate(android.view.LayoutInflater, android.view.ViewGroup, boolean);
 }


### PR DESCRIPTION
## Summary

Replace wildcard `inflate(...)` ProGuard rule with explicit overloads matching `ViewBindingCache` reflection calls:
- `inflate(LayoutInflater)`
- `inflate(LayoutInflater, ViewGroup, boolean)`

This prevents potential issues with aggressive R8 obfuscation.

## Test plan

- [x] No runtime changes, only ProGuard consumer rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)