### PR TITLE
ci: add Claude Code GitHub Action integration

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,53 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Configure Claude's behavior for Android/Gradle project
+          claude_args: |
+            --model claude-opus-4-6
+            --max-turns 15
+            --allowedTools "Bash(./gradlew check),Bash(./gradlew assembleRelease),Bash(./gradlew ktlintFormat),Bash(./gradlew koverHtmlReport),Bash(./gradlew :vbpd-core:*),Bash(./gradlew :vbpd:*),Bash(./gradlew :vbpd-reflection:*),Bash(git *)"
+            --system-prompt "Follow coding standards from CLAUDE.md. Use explicit API mode (all public declarations need visibility modifiers). Ensure Kotlin formatting with ktlintFormat before committing. Run ./gradlew check to verify changes. Target JVM 11. PRs target develop branch, except hotfixes which target master."


### PR DESCRIPTION
## Summary
- Add `.github/workflows/claude.yml` for Claude Code integration with GitHub Actions
- Triggers on @claude mentions in issues, PRs, and reviews
- Sets up JDK 17 and Gradle for Android builds
- Allows Gradle commands for check, build, format, coverage

🤖 Generated with [Claude Code](https://claude.ai/code)