### PR TITLE
fix: correct @JvmName in ViewGroupBindings, fix nullable in findRootView, add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .externalNativeBuild
 .cxx
 firebase-debug.log
+.worktrees/

--- a/vbpd-core/src/test/kotlin/dev/androidbroadcast/vbpd/EagerViewBindingPropertyTest.kt
+++ b/vbpd-core/src/test/kotlin/dev/androidbroadcast/vbpd/EagerViewBindingPropertyTest.kt
@@ -40,4 +40,15 @@ class EagerViewBindingPropertyTest {
         val second = property.getValue(thisRef, mockProperty)
         assertEquals(first, second)
     }
+
+    @Test
+    fun `clear does not affect getValue`() {
+        val binding = createMockBinding()
+        val property = EagerViewBindingProperty<Any, ViewBinding>(binding)
+        val thisRef = Any()
+
+        property.clear()
+        val result = property.getValue(thisRef, mockProperty)
+        assertEquals(binding, result)
+    }
 }

--- a/vbpd-reflection/src/main/kotlin/dev/androidbroadcast/vbpd/ViewGroupBindings.kt
+++ b/vbpd-reflection/src/main/kotlin/dev/androidbroadcast/vbpd/ViewGroupBindings.kt
@@ -14,7 +14,7 @@ import androidx.viewbinding.ViewBinding
  *
  * @return [ViewBindingProperty] that holds [ViewBinding] instance
  */
-@JvmName("viewBindingFragment")
+@JvmName("viewBindingViewGroup")
 public inline fun <reified T : ViewBinding> ViewGroup.viewBinding(
     createMethod: CreateMethod = CreateMethod.BIND,
 ): ViewBindingProperty<ViewGroup, T> = viewBinding(T::class.java, createMethod)
@@ -27,7 +27,7 @@ public inline fun <reified T : ViewBinding> ViewGroup.viewBinding(
  *
  * @return [ViewBindingProperty] that holds [ViewBinding] instance
  */
-@JvmName("viewBindingFragment")
+@JvmName("viewBindingViewGroup")
 @JvmOverloads
 public fun <T : ViewBinding> ViewGroup.viewBinding(
     viewBindingClass: Class<T>,
@@ -50,7 +50,7 @@ public fun <T : ViewBinding> ViewGroup.viewBinding(
  *
  * @return [ViewBindingProperty] that holds [ViewBinding] instance
  */
-@JvmName("viewBindingFragment")
+@JvmName("viewBindingViewGroupInflate")
 public inline fun <reified T : ViewBinding> ViewGroup.viewBinding(attachToRoot: Boolean = false): ViewBindingProperty<ViewGroup, T> =
     viewBinding(T::class.java, attachToRoot)
 
@@ -62,7 +62,7 @@ public inline fun <reified T : ViewBinding> ViewGroup.viewBinding(attachToRoot: 
  *
  * @return [ViewBindingProperty] that holds [ViewBinding] instance
  */
-@JvmName("viewBindingFragment")
+@JvmName("viewBindingViewGroupInflate")
 public fun <T : ViewBinding> ViewGroup.viewBinding(
     viewBindingClass: Class<T>,
     attachToRoot: Boolean = false,

--- a/vbpd/src/main/kotlin/dev/androidbroadcast/vbpd/internal/VbpdUtils.kt
+++ b/vbpd/src/main/kotlin/dev/androidbroadcast/vbpd/internal/VbpdUtils.kt
@@ -52,7 +52,7 @@ public fun DialogFragment.findRootView(
             if (viewBindingRootId != 0) requireViewByIdCompat(viewBindingRootId) else this
         }
     } else {
-        return requireView().findViewById(viewBindingRootId)
+        return requireView().requireViewByIdCompat(viewBindingRootId)
     }
 }
 

--- a/vbpd/src/test/kotlin/dev/androidbroadcast/vbpd/ActivityViewBindingPropertyTest.kt
+++ b/vbpd/src/test/kotlin/dev/androidbroadcast/vbpd/ActivityViewBindingPropertyTest.kt
@@ -11,6 +11,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import kotlin.reflect.KProperty
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 
 @RunWith(RobolectricTestRunner::class)
@@ -55,6 +58,37 @@ class ActivityViewBindingPropertyTest {
         val activity = controller.get()
         assertNotNull(activity.binding)
 
+        // Verify full lifecycle completes without crash
+        // onDestroy triggers clear() which nulls binding and unregisters callbacks
         controller.pause().stop().destroy()
+    }
+
+    @Test
+    fun `clear resets binding and allows recreation`() {
+        val mockProperty = mockk<KProperty<*>>(relaxed = true)
+        var callCount = 0
+        val delegate =
+            ActivityViewBindingProperty<Activity, ViewBinding> { activity ->
+                callCount++
+                mockk<ViewBinding> {
+                    every { root } returns View(activity)
+                }
+            }
+
+        val controller =
+            Robolectric
+                .buildActivity(TestActivity::class.java)
+                .create()
+                .start()
+                .resume()
+        val activity = controller.get()
+
+        val binding1 = delegate.getValue(activity, mockProperty)
+        assertEquals(1, callCount)
+
+        delegate.clear()
+        val binding2 = delegate.getValue(activity, mockProperty)
+        assertEquals(2, callCount)
+        assertNotEquals(binding1, binding2, "After clear(), a new binding should be created")
     }
 }


### PR DESCRIPTION
## Summary

- Fix `@JvmName("viewBindingFragment")` → `"viewBindingViewGroup"`/`"viewBindingViewGroupInflate"` in reflection `ViewGroupBindings.kt` (copy-paste error)
- Fix `DialogFragment.findRootView()` returning nullable from `findViewById` instead of using `requireViewByIdCompat` when `showsDialog=false`
- Add `EagerViewBindingProperty.clear()` test verifying no-op behavior
- Add `ActivityViewBindingProperty` test verifying binding recreation after `clear()`

## Test plan
- [x] `./gradlew check` passes
- [ ] Verify `@JvmName` change doesn't break Java callers (binary-incompatible for reflection module's ViewGroup extensions from Java)

🤖 Generated with [Claude Code](https://claude.com/claude-code)